### PR TITLE
Upgrade module to Terraform v0.13

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+#### Developer Checklist
+
+- [ ] The README contains the correct list of dependencies, inputs, and outputs (e.g., `terraform-docs markdown .` has been run)
+
+#### What does this PR do?
+
+A few sentences describing the overall goals of the pull request's commits.
+Why are we making these changes? Is there more work to be done to fully
+achieve these goals?
+
+#### Helpful background context
+
+Describe any additional context beyond what the PR accomplishes if it is likely
+to be useful to a reviewer.
+
+Delete this section if it isn't applicable to the PR.
+
+#### What are the relevant tickets?
+
+Include links to Jira Software and/or Jira Service Managament tickets here.
+
+#### Requires Database Migrations?
+YES | NO
+
+#### Includes new or updated dependencies?
+YES | NO

--- a/.github/workflows/tf-validate.yml
+++ b/.github/workflows/tf-validate.yml
@@ -1,0 +1,32 @@
+name: Terraform Validate
+
+on: 
+  pull_request:
+    branches:
+      - main
+  push: 
+    branches-ignore:
+      - 'main'
+
+# Set defaults
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  validate:
+    name: Check Terraform syntax
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # Setup terraform with the correct version
+      - name: Terraform Setup
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.13.7
+    
+      # Run Terraform Validate
+      - name: Validate
+        run: terraform fmt -check; terraform init -backend=false; terraform validate

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-before_install:
-  - wget https://releases.hashicorp.com/terraform/0.12.9/terraform_0.12.9_linux_amd64.zip -O /tmp/tf.zip
-  - unzip -d bin/ /tmp/tf.zip
-  - export PATH=$PATH:$PWD/bin
-script:
-  - terraform fmt -check=true
-  - terraform validate

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
+# Module purpose
+
 This module provides consistent naming for Terraform resources. It should be used for all our Terraform configs. The `tags` output should be used for any AWS resources that support tags.
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| name | App name | string | - | yes |
-| tags | Map of additional tags for the resource | map | `<map>` | no |
+|------|-------------|------|---------|:--------:|
+| name | App name | `string` | n/a | yes |
+| tags | Map of additional tags for the resource | `map(string)` | `{}` | no |
 
 ## Outputs
 
@@ -13,4 +15,3 @@ This module provides consistent naming for Terraform resources. It should be use
 |------|-------------|
 | name | Normalized name for resource |
 | tags | Common set of tags to apply to resources |
-

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
-/**
- * This module provides consistent naming for Terraform resources. It should be used for all our Terraform configs. The `tags` output should be used for any AWS resources that support tags.
- */
+## This module provides consistent naming for Terraform resources. It should be used for all our 
+## Terraform configs. The `tags` output should be used for any AWS resources that support tags.
 
 locals {
   appname     = lower(var.name)

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,10 @@
 variable "name" {
   description = "App name"
+  type        = string
 }
 
 variable "tags" {
   description = "Map of additional tags for the resource"
+  type        = map(string)
   default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,4 +6,3 @@ variable "tags" {
   description = "Map of additional tags for the resource"
   default     = {}
 }
-

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 0.13"
 }


### PR DESCRIPTION
#### Developer Checklist

- [X] The README contains the correct list of dependencies, inputs, and outputs (e.g., `terraform-docs markdown .` has been run)

#### What does this PR do?

In order to upgrade the mitlib-terraform to work with Terraform v0.13, we need to upgrade all of the modules to support v0.13.

**The expectation is that the 3 other engineers working on the Terraform Upgrade project will review this PR and the details of the commits. This is one of the easiest modules for us to upgrade, but it is also a template for the process of upgrading the other modules we maintain.**

How this addresses that need:
* The only 0.13-related change to this code is updating the required_version constraint in the `terraform { }` block.

There are a few other changes being introduced as part of this upgrade:
* .travis.yml is removed to disconnect this repo from TravisCI
* a GitHub Action is introduced to replace Travis (for checking Terraform syntax and validating the code)
* a modified version of our standard Terraform PR template is now included in this repository.

Finally, there is a "prelease" tag ("0.13") on this branch. Once the PR is reviewed and approved, it will be merge to the master branch and the "prerelease" flag will be removed from the release tag.

#### Helpful background context

See this overview document in the InfraEng Private KB:
https://mitlibraries.atlassian.net/l/c/6MnojfgV

#### What are the relevant tickets?

https://mitlibraries.atlassian.net/browse/IN-224

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
